### PR TITLE
Aldoni/forigi lingvojn

### DIFF
--- a/cfg/lingvoj.xml
+++ b/cfg/lingvoj.xml
@@ -56,12 +56,11 @@
   <lingvo kodo="gd">skotgaela</lingvo>
   <lingvo kodo="gl">galega</lingvo>
   <lingvo kodo="gn">gvarania</lingvo>
-  <lingvo kodo="gv">manksa</lingvo>
   <lingvo kodo="goyu">tajvana</lingvo>
   <lingvo kodo="grc">malnovgreka</lingvo>
   <lingvo kodo="gu">guĝarata</lingvo>
+  <lingvo kodo="gv">manksa</lingvo>
   <lingvo kodo="ha">haŭsa</lingvo>
-  <lingvo kodo="hbs">serbokroata</lingvo>
   <lingvo kodo="he">hebrea</lingvo>
   <lingvo kodo="hi">hinda</lingvo>
   <lingvo kodo="hmn">monga</lingvo>
@@ -81,7 +80,8 @@
   <lingvo kodo="iu">inuktituta</lingvo>
   <lingvo kodo="ja">japana</lingvo>
   <lingvo kodo="jbo">loĵbana</lingvo>
-  <lingvo kodo="jw">java</lingvo> <!-- = jv -->
+  <lingvo kodo="jv">java</lingvo>
+  <lingvo kodo="jw">java</lingvo> <!-- forigi kiam neuzata -->
   <lingvo kodo="ka">kartvela</lingvo>
   <lingvo kodo="kek">kekĉia</lingvo>
   <lingvo kodo="kg">konga</lingvo>
@@ -97,6 +97,7 @@
   <lingvo kodo="la">latineca</lingvo>
   <lingvo kodo="lat">latina</lingvo>
   <lingvo kodo="lb">luksemburga</lingvo>
+  <lingvo kodo="lfn">elefena</lingvo>
   <lingvo kodo="li">limburga</lingvo>
   <lingvo kodo="lld">ladina</lingvo>
   <lingvo kodo="ln">lingala</lingvo>
@@ -170,19 +171,20 @@
   <lingvo kodo="tl">filipina</lingvo>
   <lingvo kodo="tn">cvana</lingvo>
   <lingvo kodo="to">tongaa</lingvo>
-  <lingvo kodo="tp">tokipona</lingvo>
+  <lingvo kodo="tok">tokipona</lingvo>
+  <lingvo kodo="tp">tokipona</lingvo> <!-- forigi kiam neuzata -->
   <lingvo kodo="tr">turka</lingvo>
   <lingvo kodo="ts">conga</lingvo>
   <lingvo kodo="tt">tatara</lingvo>
-  <lingvo kodo="tw">akana</lingvo>
+  <lingvo kodo="tw">tvia</lingvo>
   <lingvo kodo="ug">ujgura</lingvo>
   <lingvo kodo="uk">ukraina</lingvo>
   <lingvo kodo="ur">urdua</lingvo>
   <lingvo kodo="uz">uzbeka</lingvo>
-  <lingvo kodo="vi">vjetnama</lingvo>
   <lingvo kodo="ve">vendaa</lingvo>
-  <lingvo kodo="vro">voroa</lingvo>
+  <lingvo kodo="vi">vjetnama</lingvo>
   <lingvo kodo="vo">volapuka</lingvo>
+  <lingvo kodo="vro">voroa</lingvo>
   <lingvo kodo="war">varaja</lingvo>
   <lingvo kodo="wo">volofa</lingvo>
   <lingvo kodo="wym">vilamovica</lingvo>


### PR DESCRIPTION
* Tokipono nun havas oficialan ISO-kodon, indas aldoni ĝin, kaj ŝanĝi "tp" ĉie al "tok", kaj poste forigi "tp".
* "tw" estas por la tvia lingvo, la akana jam aperas en la listo.
* Indas ŝanĝi "jw" al la oficiala ISO-kodo "jv".
* Indas uzi nur unu kodon por la serbokroata, nun la lingvo aperas duoble en la listo.