### PR TITLE
Aldonas vorto speco tablo

### DIFF
--- a/sql/revo-skemo.sql
+++ b/sql/revo-skemo.sql
@@ -40,6 +40,11 @@ CREATE TABLE artikolo (
   txt TEXT
 );
 
+CREATE TABLE vorto_speco (
+  mrk TEXT PRIMARY KEY NOT NULL,
+  speco TEXT NOT NULL
+);
+
 CREATE TABLE agordo (
   nomo TEXT PRIMARY KEY NOT NULL,
   valoro TEXT

--- a/xsl/revo_sql.xsl
+++ b/xsl/revo_sql.xsl
@@ -80,6 +80,12 @@ INSERT INTO nodo(mrk,art,kap,num) VALUES('</xsl:text>
     </xsl:call-template>
   </xsl:for-each>
 
+  <xsl:for-each select="gra/vspec">
+    <xsl:call-template name="vorto-speco">
+      <xsl:with-param name="mrk" select="$mrk"/>
+    </xsl:call-template>
+  </xsl:for-each>
+
   <xsl:apply-templates select="snc/subsnc"/>
 
 </xsl:template>
@@ -117,6 +123,12 @@ INSERT INTO nodo(mrk,art,kap,num) VALUES('</xsl:text>
 
   <xsl:for-each select="ref">
     <xsl:call-template name="referenco">
+      <xsl:with-param name="mrk" select="$mrk"/>
+    </xsl:call-template>
+  </xsl:for-each>
+  
+  <xsl:for-each select="gra/vspec">
+    <xsl:call-template name="vorto-speco">
       <xsl:with-param name="mrk" select="$mrk"/>
     </xsl:call-template>
   </xsl:for-each>
@@ -254,6 +266,15 @@ INSERT INTO referenco(mrk,cel,tip) VALUES('</xsl:text>
 <xsl:text>');</xsl:text>
 </xsl:template>
 
+<xsl:template name="vorto-speco">
+  <xsl:param name="mrk"/>
+<xsl:text>                                                                                                             
+INSERT INTO vorto_speco(mrk, speco) VALUES('</xsl:text>
+<xsl:value-of select="$mrk"/>
+<xsl:text>','</xsl:text>
+<xsl:value-of select="."/>
+<xsl:text>');</xsl:text>
+</xsl:template>
 
 <!--
 


### PR DESCRIPTION
1. La 'vspec' parto de la vortaro estas tre utila ero, kiu
   povas informi lernantojn pri la tipo de la verbo (ntr, tr).

2. Mi proponas eligi tiun tipon ankau en la oficiala revo sqlite3
   vortaro, ĉar poste tio faciligas fari lernkartojn por komencantojn
   (ekzemple por Anki).