### PR TITLE
Aldoni la livonan lingvon (`liv`)

### DIFF
--- a/cfg/lingvoj.xml
+++ b/cfg/lingvoj.xml
@@ -99,6 +99,7 @@
   <lingvo kodo="lb">luksemburga</lingvo>
   <lingvo kodo="lfn">elefena</lingvo>
   <lingvo kodo="li">limburga</lingvo>
+  <lingvo kodo="liv">livona</lingvo>
   <lingvo kodo="lld">ladina</lingvo>
   <lingvo kodo="ln">lingala</lingvo>
   <lingvo kodo="lo">laŭa</lingvo>


### PR DESCRIPTION
En la [limburga indekso](https://www.reta-vortaro.de/revo/inx/lx_li_a.html) aperas kaj limburgaj kaj livonaj tradukoj. Ni aldonu la ĝustan kodon por la livona, kaj korektu la tradukojn.