### PR TITLE
Signolingvoj

### DIFF
--- a/cfg/lingvoj.xml
+++ b/cfg/lingvoj.xml
@@ -147,7 +147,7 @@
   <lingvo kodo="sd">sinda</lingvo>
   <lingvo kodo="se">nordsamea</lingvo>
   <lingvo kodo="sg">sangoa</lingvo>
-  <lingvo kodo="sgn">gesta</lingvo> <!-- Signuno kaj aldonoj -->
+  <lingvo kodo="ils">gestuna</lingvo> <!-- Signuno kaj aldonoj -->
   <lingvo kodo="sh">serbokroata</lingvo>
   <lingvo kodo="si">sinhala</lingvo>
   <lingvo kodo="sk">slovaka</lingvo>


### PR DESCRIPTION
Estas interesa ideo aldoni signolingvajn tradukojn, sed mi vidas, ke vi uzis la kodon "sgn". Tiu kodo estas ĝenerale por signolingvoj, do ne nur por Gestuno, sed ankaŭ por la usona signolingvo, la nederlanda signolingvo, ktp... Do eble estus pli bone uzi aliajn kodojn:

```xml
  <lingvo kodo="ase">usona signolingv</lingvo>
  <lingvo kodo="dse">nederlanda signolingv</lingvo>
  <lingvo kodo="ils">gestuna</lingvo>
```